### PR TITLE
feat(cors): introduce WebQuark.Cors project (ASP.NET Core & OWIN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ WebQuark is split into small, focused projects:
 | `WebQuark.Session`         | Cross-platform session manager with support for encrypted object storage    | [![WebQuark.Session](https://img.shields.io/nuget/v/WebQuark.Session?style=plastic)](https://www.nuget.org/packages/WebQuark.Session) |
 | `WebQuark.QueryString`     | Strongly-typed query string parser and encoder utilities                    | [![WebQuark.QueryString](https://img.shields.io/nuget/v/WebQuark.QueryString?style=plastic)](https://www.nuget.org/packages/WebQuark.QueryString) |
 | `WebQuark.Extensions`      | Extension methods to simplify integration and enhance core WebQuark modules | [![WebQuark.Extensions](https://img.shields.io/nuget/v/WebQuark.Extensions?style=plastic)](https://www.nuget.org/packages/WebQuark.Extensions) |
+| `WebQuark.Cors`            | CORS helpers with secure defaults, prebuilt policies, ASP.NET Core & OWIN   | [![WebQuark.Cors](https://img.shields.io/nuget/v/WebQuark.Cors?style=plastic)](https://www.nuget.org/packages/WebQuark.Cors) |
 
 ## Integrating WebQuark in Your Project
 This guide shows how to integrate the WebQuark library for unified abstraction across different .NET platforms, including .NET Core and legacy .NET Framework.

--- a/src/WebQuark.Cors/Extensions/WebQuarkCorsExtensions.cs
+++ b/src/WebQuark.Cors/Extensions/WebQuarkCorsExtensions.cs
@@ -18,6 +18,20 @@ namespace WebQuark.Cors.Extensions
         /// <summary>
         /// Registers WebQuark CORS with two named policies: a public read-only policy and a trusted allowlist policy.
         /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="configure">Optional configuration callback for <see cref="WebQuarkCorsOptions"/>.</param>
+        /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// // Program.cs (ASP.NET Core)
+        /// builder.Services.AddWebQuarkCors(o =>
+        /// {
+        ///     o.AllowedOrigins   = new[] { "https://app.example.com", "https://localhost:5173" };
+        ///     o.AllowCredentials = true;   // disallowed with "*"
+        ///     o.PreflightMaxAge  = TimeSpan.FromHours(2);
+        /// });
+        /// </code>
+        /// </example>
         public static IServiceCollection AddWebQuarkCors(
             this IServiceCollection services,
             Action<WebQuarkCorsOptions> configure = null)
@@ -33,6 +47,24 @@ namespace WebQuark.Cors.Extensions
         /// <summary>
         /// Applies a default CORS policy to the pipeline. If you need per-endpoint control, omit this and use RequireCors.
         /// </summary>
+        /// <param name="app">The application builder.</param>
+        /// <param name="defaultPolicy">Optional policy name to apply (e.g., "cors-trusted" or "cors-public").</param>
+        /// <returns>The same <see cref="IApplicationBuilder"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// // Apply a default policy to the whole app:
+        /// app.UseWebQuarkCors("cors-trusted");
+        /// </code>
+        /// <code>
+        /// // Per-endpoint usage (Minimal APIs):
+        /// app.MapGet("/ping", () => "ok").RequireCors("cors-public");
+        /// </code>
+        /// <code>
+        /// // Per-controller usage (MVC):
+        /// // [EnableCors("cors-trusted")]
+        /// // public class MyController : ControllerBase { ... }
+        /// </code>
+        /// </example>
         public static IApplicationBuilder UseWebQuarkCors(
             this IApplicationBuilder app,
             string defaultPolicy = null)
@@ -105,6 +137,21 @@ namespace WebQuark.Cors.Extensions
         /// <summary>
         /// Applies the public (read-only, no credentials) policy across the OWIN pipeline.
         /// </summary>
+        /// <param name="app">The OWIN app builder.</param>
+        /// <param name="options">Optional CORS options; if null, defaults are used.</param>
+        /// <returns>The same <see cref="IAppBuilder"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// // Startup.cs (OWIN)
+        /// public void Configuration(IAppBuilder app)
+        /// {
+        ///     app.UseWebQuarkCorsPublic(new WebQuark.Cors.Options.WebQuarkCorsOptions
+        ///     {
+        ///         PreflightMaxAge = TimeSpan.FromMinutes(30)
+        ///     });
+        /// }
+        /// </code>
+        /// </example>
         public static IAppBuilder UseWebQuarkCorsPublic(this IAppBuilder app, WebQuarkCorsOptions options = null)
         {
             var o = options ?? new WebQuarkCorsOptions();
@@ -128,13 +175,19 @@ namespace WebQuark.Cors.Extensions
                 }
             };
 
-            // Access-Control-Max-Age (non disponibile nativamente: lo impostiamo noi per OPTIONS)
+            // Preflight detection + Vary
             app.Use(async (ctx, next) =>
             {
-                if (string.Equals(ctx.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase))
+                var isOptions = string.Equals(ctx.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase);
+                var origin    = ctx.Request.Headers.Get("Origin");
+                var acrm      = ctx.Request.Headers.Get("Access-Control-Request-Method");
+
+                if (isOptions && !string.IsNullOrEmpty(origin) && !string.IsNullOrEmpty(acrm))
                 {
                     ctx.Response.Headers.Set("Access-Control-Max-Age", ((int)o.PreflightMaxAge.TotalSeconds).ToString());
+                    ctx.Response.Headers.Set("Vary", "Origin, Access-Control-Request-Headers, Access-Control-Request-Method");
                 }
+
                 await next.Invoke();
             });
 
@@ -144,6 +197,25 @@ namespace WebQuark.Cors.Extensions
         /// <summary>
         /// Applies the trusted allowlist policy (supports wildcard subdomains and optional credentials).
         /// </summary>
+        /// <param name="app">The OWIN app builder.</param>
+        /// <param name="options">CORS options (must not be null for 'trusted').</param>
+        /// <returns>The same <see cref="IAppBuilder"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// // Startup.cs (OWIN)
+        /// public void Configuration(IAppBuilder app)
+        /// {
+        ///     var cors = new WebQuark.Cors.Options.WebQuarkCorsOptions
+        ///     {
+        ///         AllowedOrigins   = new[] { "https://portal.example.it", "http://localhost:3000" },
+        ///         AllowCredentials = true, // requires explicit allowlist (no "*")
+        ///         PreflightMaxAge  = TimeSpan.FromMinutes(30)
+        ///     };
+        ///
+        ///     app.UseWebQuarkCorsTrusted(cors);
+        /// }
+        /// </code>
+        /// </example>
         public static IAppBuilder UseWebQuarkCorsTrusted(this IAppBuilder app, WebQuarkCorsOptions options)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
@@ -187,22 +259,50 @@ namespace WebQuark.Cors.Extensions
                 }
             };
 
-            // Access-Control-Max-Age per preflight
+            // Preflight detection + Vary
             app.Use(async (ctx, next) =>
             {
-                if (string.Equals(ctx.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase))
+                var isOptions = string.Equals(ctx.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase);
+                var origin    = ctx.Request.Headers.Get("Origin");
+                var acrm      = ctx.Request.Headers.Get("Access-Control-Request-Method");
+
+                if (isOptions && !string.IsNullOrEmpty(origin) && !string.IsNullOrEmpty(acrm))
                 {
                     ctx.Response.Headers.Set("Access-Control-Max-Age", ((int)options.PreflightMaxAge.TotalSeconds).ToString());
+                    ctx.Response.Headers.Set("Vary", "Origin, Access-Control-Request-Headers, Access-Control-Request-Method");
                 }
+
                 await next.Invoke();
             });
 
             return app.UseCors(new CorsOptions { PolicyProvider = provider });
         }
-
+    
         /// <summary>
         /// Compatibility helper: maps "cors-public" / "cors-trusted" to the corresponding OWIN setup.
         /// </summary>
+        /// <param name="app">The OWIN app builder.</param>
+        /// <param name="defaultPolicy">Policy name to apply ("cors-public" or "cors-trusted").</param>
+        /// <param name="options">Optional CORS options (required when using "cors-trusted").</param>
+        /// <returns>The same <see cref="IAppBuilder"/> for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// // Startup.cs (OWIN)
+        /// public void Configuration(IAppBuilder app)
+        /// {
+        ///     var opts = new WebQuark.Cors.Options.WebQuarkCorsOptions
+        ///     {
+        ///         AllowedOrigins   = new[] { "https://portal.example.it" },
+        ///         AllowCredentials = true
+        ///     };
+        ///
+        ///     // Apply by name using the compatibility helper:
+        ///     app.UseWebQuarkCors("cors-trusted", opts);
+        ///     // or:
+        ///     // app.UseWebQuarkCors("cors-public");
+        /// }
+        /// </code>
+        /// </example>
         public static IAppBuilder UseWebQuarkCors(this IAppBuilder app, string defaultPolicy, WebQuarkCorsOptions options = null)
         {
             if (string.IsNullOrWhiteSpace(defaultPolicy)) return app;

--- a/src/WebQuark.Cors/Internal/OriginMatcher.cs
+++ b/src/WebQuark.Cors/Internal/OriginMatcher.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 
 namespace WebQuark.Cors.Internal
 {
-
     /// <summary>
     /// Utilities to build host-matching predicates for CORS Origin validation.
     /// </summary>

--- a/src/WebQuark.Cors/WebQuark.Cors.csproj
+++ b/src/WebQuark.Cors/WebQuark.Cors.csproj
@@ -5,6 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageProjectUrl>https://github.com/engineering87/WebQuark</PackageProjectUrl>
+    <PackageIcon>WebQuark_logo.jpg</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/engineering87/WebQuark</RepositoryUrl>
+    <Description>CORS helpers for .NET: ready policies, wildcard origins, proper preflight, secure defaults</Description>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net8.0'">
@@ -15,6 +21,17 @@
     <PackageReference Include="Microsoft.Owin" Version="4.2.3" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.3" />
     <PackageReference Include="Microsoft.AspNet.Cors" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\img\WebQuark_logo.jpg">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/WebQuark.Request/WebQuark.HttpRequest.csproj
+++ b/src/WebQuark.Request/WebQuark.HttpRequest.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.8" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebQuark.Session/WebQuark.Session.csproj
+++ b/src/WebQuark.Session/WebQuark.Session.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.8" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Introduce a dedicated CORS module with secure defaults and ready-made policies for ASP.NET Core and legacy OWIN.

## What’s included
- New package: WebQuark.Cors
- Guardrails: block AllowCredentials=true with *
- OWIN fix: set Access-Control-Max-Age only on real preflight; add Vary header
- XML-doc usage examples + README update